### PR TITLE
fix: Return the Http Request error properly

### DIFF
--- a/Device.go
+++ b/Device.go
@@ -275,7 +275,8 @@ func (dev *Device) SendSoap(endpoint string, xmlRequestBody string) (resp *http.
 	if dev.params.AuthMode == DigestAuth || dev.params.AuthMode == Both {
 		resp, err = dev.digestClient.Do(endpoint, soap.String())
 	} else {
-		req, err := createHttpRequest(endpoint, soap.String())
+		var req *http.Request
+		req, err = createHttpRequest(endpoint, soap.String())
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Remove the `error variable declaration` to return the Http Request error properly

Change from
```
func (dev *Device) SendSoap(endpoint string, xmlRequestBody string) (resp *http.Response, err error) {
	...
	if ... {
		...
	} else {
		req, err := createHttpRequest(endpoint, soap.String())
		if err != nil {
			return nil, err
		}
		resp, err = dev.params.HttpClient.Do(req)
	}
	return resp, err
}
```
To
```
func (dev *Device) SendSoap(endpoint string, xmlRequestBody string) (resp *http.Response, err error) {
	...
	if ... {
		...
	} else {
		var req *http.Request
		req, err = createHttpRequest(endpoint, soap.String())
		if err != nil {
			return nil, err
		}
		resp, err = dev.params.HttpClient.Do(req)
	}
	return resp, err
}
```
Signed-off-by: bruce <weichou1229@gmail.com>