### PR TITLE
feat: Parse UUID from the EndpointReference

### DIFF
--- a/Device.go
+++ b/Device.go
@@ -16,7 +16,6 @@ import (
 	"github.com/IOTechSystems/onvif/device"
 	"github.com/IOTechSystems/onvif/gosoap"
 	"github.com/IOTechSystems/onvif/networking"
-
 	"github.com/beevik/etree"
 )
 
@@ -89,11 +88,12 @@ type Device struct {
 }
 
 type DeviceParams struct {
-	Xaddr      string
-	Username   string
-	Password   string
-	HttpClient *http.Client
-	AuthMode   string
+	Xaddr              string
+	EndpointRefAddress string
+	Username           string
+	Password           string
+	HttpClient         *http.Client
+	AuthMode           string
 }
 
 //GetServices return available endpoints

--- a/ws-discovery/networking_test.go
+++ b/ws-discovery/networking_test.go
@@ -1,0 +1,56 @@
+package wsdiscovery
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDevicesFromProbeResponses(t *testing.T) {
+	probeResponses := []string{
+		`<env:Envelope>
+			<env:Header></env:Header>
+			<env:Body>
+				<d:ProbeMatches>
+					<d:ProbeMatch>
+						<wsadis:EndpointReference>
+							<wsadis:Address>urn:uuid:cea94000-fb96-11b3-8260-686dbc5cb15d</wsadis:Address>
+						</wsadis:EndpointReference>
+						<d:Types>dn:NetworkVideoTransmitter tds:Device</d:Types>
+						<d:Scopes>onvif://www.onvif.org/type/video_encoder onvif://www.onvif.org/Profile/Streaming onvif://www.onvif.org/MAC/68:6d:bc:5c:b1:5d onvif://www.onvif.org/hardware/DFI6256TE http:123</d:Scopes>
+						<d:XAddrs>http://192.168.12.123/onvif/device_service</d:XAddrs>
+						<d:MetadataVersion>10</d:MetadataVersion>
+					</d:ProbeMatch>
+				</d:ProbeMatches>
+			</env:Body>
+		</env:Envelope>`,
+		`<SOAP-ENV:Envelope>
+		<SOAP-ENV:Header></SOAP-ENV:Header>
+		<SOAP-ENV:Body>
+			<wsdd:ProbeMatches>
+				<wsdd:ProbeMatch>
+					<wsa:EndpointReference>
+						<wsa:Address>uuid:3fa1fe68-b915-4053-a3e1-c006c3afec0e</wsa:Address>
+						<wsa:ReferenceProperties>
+						</wsa:ReferenceProperties>
+						<wsa:PortType>ttl</wsa:PortType>
+					</wsa:EndpointReference>
+					<wsdd:Types>tdn:NetworkVideoTransmitter</wsdd:Types>
+					<wsdd:Scopes>onvif://www.onvif.org/name/TP-IPC onvif://www.onvif.org/hardware/MODEL onvif://www.onvif.org/Profile/Streaming onvif://www.onvif.org/location/ShenZhen onvif://www.onvif.org/type/NetworkVideoTransmitter </wsdd:Scopes>
+					<wsdd:XAddrs>http://192.168.12.128:2020/onvif/device_service</wsdd:XAddrs>
+					<wsdd:MetadataVersion>1</wsdd:MetadataVersion>
+				</wsdd:ProbeMatch>
+			</wsdd:ProbeMatches>
+		</SOAP-ENV:Body>
+		</SOAP-ENV:Envelope>`,
+	}
+
+	devices, err := devicesFromProbeResponses(probeResponses)
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(devices))
+	assert.Equal(t, devices[0].GetDeviceParams().Xaddr, "192.168.12.123")
+	assert.Equal(t, devices[0].GetDeviceParams().EndpointRefAddress, "cea94000-fb96-11b3-8260-686dbc5cb15d")
+	assert.Equal(t, devices[1].GetDeviceParams().Xaddr, "192.168.12.128:2020")
+	assert.Equal(t, devices[1].GetDeviceParams().EndpointRefAddress, "3fa1fe68-b915-4053-a3e1-c006c3afec0e")
+}


### PR DESCRIPTION
We have indeed confirmed that even when the device IP address changes, the EndpointReference stays the same, and is unique to all of our cameras.

Signed-off-by: bruce <weichou1229@gmail.com>