### PR TITLE
feat: Parse EventProperties TopicSet from XML to Map

### DIFF
--- a/event/type_test.go
+++ b/event/type_test.go
@@ -1,0 +1,75 @@
+package event
+
+import (
+	"encoding/xml"
+	"testing"
+
+	"github.com/IOTechSystems/onvif/xsd"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var eventPropertiesData = []byte(`
+        <tev:GetEventPropertiesResponse>
+            <tev:TopicNamespaceLocation>http://www.onvif.org/onvif/ver10/topics/topicns.xml</tev:TopicNamespaceLocation>
+            <wsnt:FixedTopicSet>true</wsnt:FixedTopicSet>
+            <wstop:TopicSet>
+                <tns1:UserAlarm wstop:topic="true">
+                    <tnshik:IllegalAccess wstop:topic="true"/>
+                </tns1:UserAlarm>
+                <tns1:RuleEngine wstop:topic="true">
+                    <CellMotionDetector wstop:topic="true">
+                        <Motion wstop:topic="true">
+                            <tt:MessageDescription IsProperty="true">
+                                <tt:Source>
+                                    <tt:SimpleItemDescription Name="VideoSourceConfigurationToken" Type="tt:ReferenceToken"/>
+                                    <tt:SimpleItemDescription Name="VideoAnalyticsConfigurationToken" Type="tt:ReferenceToken"/>
+                                    <tt:SimpleItemDescription Name="Rule" Type="xs:string"/>
+                                </tt:Source>
+                                <tt:Data>
+                                    <tt:SimpleItemDescription Name="IsMotion" Type="xs:boolean"/>
+                                </tt:Data>
+                            </tt:MessageDescription>
+                        </Motion>
+                    </CellMotionDetector>
+                    <TamperDetector wstop:topic="true">
+                        <Tamper wstop:topic="true">
+                            <tt:MessageDescription IsProperty="true">
+                                <tt:Source>
+                                    <tt:SimpleItemDescription Name="VideoSourceConfigurationToken" Type="tt:ReferenceToken"/>
+                                    <tt:SimpleItemDescription Name="VideoAnalyticsConfigurationToken" Type="tt:ReferenceToken"/>
+                                    <tt:SimpleItemDescription Name="Rule" Type="xs:string"/>
+                                </tt:Source>
+                                <tt:Data>
+                                    <tt:SimpleItemDescription Name="IsTamper" Type="xs:boolean"/>
+                                </tt:Data>
+                            </tt:MessageDescription>
+                        </Tamper>
+                    </TamperDetector>
+                </tns1:RuleEngine>
+            </wstop:TopicSet>
+            <tev:MessageContentFilterDialect>http://www.onvif.org/ver10/tev/messageContentFilter/ItemFilter</tev:MessageContentFilterDialect>
+            <tev:MessageContentSchemaLocation>http://www.onvif.org/onvif/ver10/schema/onvif.xsd</tev:MessageContentSchemaLocation>
+        </tev:GetEventPropertiesResponse>
+`)
+
+func TestEventPropertiesUnmarshalXML(t *testing.T) {
+	res := GetEventPropertiesResponse{}
+	err := xml.Unmarshal(eventPropertiesData, &res)
+	require.NoError(t, err)
+	assert.Equal(t, FixedTopicSet(true), *res.FixedTopicSet)
+	assert.Equal(t, xsd.AnyURI("http://www.onvif.org/ver10/tev/messageContentFilter/ItemFilter"), *res.MessageContentFilterDialect)
+	assert.Equal(t, xsd.AnyURI("http://www.onvif.org/onvif/ver10/schema/onvif.xsd"), *res.MessageContentSchemaLocation)
+	userAlarm, exists := map[string]interface{}(*res.TopicSet)["tns1:UserAlarm"]
+	assert.True(t, exists)
+	_, exists = (userAlarm).(map[string]interface{})["tnshik:IllegalAccess"]
+	assert.True(t, exists)
+	ruleEngine, exists := map[string]interface{}(*res.TopicSet)["tns1:RuleEngine"]
+	assert.True(t, exists)
+	tamperDetector, exists := (ruleEngine).(map[string]interface{})["TamperDetector"]
+	assert.True(t, exists)
+	tamper, exists := (tamperDetector).(map[string]interface{})["Tamper"]
+	assert.True(t, exists)
+	_, exists = (tamper).(map[string]interface{})["tt:MessageDescription"]
+	assert.True(t, exists)
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/beevik/etree v1.1.0
+	github.com/clbanning/mxj/v2 v2.3.2
 	github.com/elgs/gostrgen v0.0.0-20161222160715-9d61ae07eeae
 	github.com/gin-gonic/gin v1.6.2
 	github.com/gofrs/uuid v3.2.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/beevik/etree v1.1.0 h1:T0xke/WvNtMoCqgzPhkX2r4rjY3GDZFi+FjpRZY2Jbs=
 github.com/beevik/etree v1.1.0/go.mod h1:r8Aw8JqVegEf0w2fDnATrX9VpkMcyFeM0FhwO62wh+A=
+github.com/clbanning/mxj/v2 v2.3.2 h1:DSkU65zfrBHtrggxd54X9pK1z/Lw2OwSW5D8p+x1toE=
+github.com/clbanning/mxj/v2 v2.3.2/go.mod h1:hNiWqW14h+kc+MdF9C6/YoRfjEJoR3ou6tn/Qo+ve2s=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Since the EventProperties TopicSet is various between different cameras, so consider parse the EventProperties TopicSet from XML to Map instead of specified struct.

Signed-off-by: bruce <weichou1229@gmail.com>