### PR TITLE
feat: improve ws-discovery multicast probe logic

### DIFF
--- a/ws-discovery/ws-discovery.go
+++ b/ws-discovery/ws-discovery.go
@@ -7,22 +7,41 @@ import (
 	"github.com/beevik/etree"
 )
 
+// BuildProbeMessage generates a SOAP ws-discovery Probe message
+//
+// Example Message:
+//
+//	<?xml version="1.0" encoding="UTF-8"?>
+//	<soap-env:Envelope xmlns:soap-env="http://www.w3.org/2003/05/soap-envelope"
+//				       xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+//				       xmlns:d="http://schemas.xmlsoap.org/ws/2005/04/discovery"
+//				       xmlns:dn="http://www.onvif.org/ver10/network/wsdl"
+//				       xmlns:soap-enc="http://www.w3.org/2003/05/soap-encoding">
+//	   <soap-env:Header>
+//		  <a:Action mustUnderstand="1">http://schemas.xmlsoap.org/ws/2005/04/discovery/Probe</a:Action>
+//		  <a:MessageID>uuid:a277f13a-ecae-4492-9d6a-218982122d1c</a:MessageID>
+//		  <a:To mustUnderstand="1">urn:schemas-xmlsoap-org:ws:2005:04:discovery</a:To>
+//	   </soap-env:Header>
+//	   <soap-env:Body>
+//		  <d:Probe>
+//			 <d:Types>dn:NetworkVideoTransmitter</d:Types>
+//		  </d:Probe>
+//	   </soap-env:Body>
+//	</soap-env:Envelope>
 func BuildProbeMessage(uuidV4 string, scopes, types []string, nmsp map[string]string) gosoap.SoapMessage {
-	//Список namespace
+	// Namespace List
 	namespaces := make(map[string]string)
 	namespaces["a"] = "http://schemas.xmlsoap.org/ws/2004/08/addressing"
-	//namespaces["d"] = "http://schemas.xmlsoap.org/ws/2005/04/discovery"
+	namespaces["d"] = "http://schemas.xmlsoap.org/ws/2005/04/discovery"
+	namespaces["dn"] = "http://www.onvif.org/ver10/network/wsdl"
 
 	probeMessage := gosoap.NewEmptySOAP()
-
 	probeMessage.AddRootNamespaces(namespaces)
-	//if len(nmsp) != 0 {
-	//	probeMessage.AddRootNamespaces(nmsp)
-	//}
+	if len(nmsp) != 0 {
+		probeMessage.AddRootNamespaces(nmsp)
+	}
 
-	//fmt.Println(probeMessage.String())
-
-	//Содержимое Head
+	// Probe Header
 	var headerContent []*etree.Element
 
 	action := etree.NewElement("a:Action")
@@ -32,49 +51,25 @@ func BuildProbeMessage(uuidV4 string, scopes, types []string, nmsp map[string]st
 	msgID := etree.NewElement("a:MessageID")
 	msgID.SetText("uuid:" + uuidV4)
 
-	replyTo := etree.NewElement("a:ReplyTo")
-	replyTo.CreateElement("a:Address").SetText("http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous")
-
 	to := etree.NewElement("a:To")
 	to.SetText("urn:schemas-xmlsoap-org:ws:2005:04:discovery")
 	to.CreateAttr("mustUnderstand", "1")
 
-	headerContent = append(headerContent, action, msgID, replyTo, to)
+	headerContent = append(headerContent, action, msgID, to)
 	probeMessage.AddHeaderContents(headerContent)
 
-	//Содержимое Body
-	probe := etree.NewElement("Probe")
-	probe.CreateAttr("xmlns", "http://schemas.xmlsoap.org/ws/2005/04/discovery")
+	// Probe Body
+	probe := etree.NewElement("d:Probe")
 
 	if len(types) != 0 {
 		typesTag := etree.NewElement("d:Types")
-		if len(nmsp) != 0 {
-			for key, value := range nmsp {
-				typesTag.CreateAttr("xmlns:"+key, value)
-			}
-		}
-		typesTag.CreateAttr("xmlns:d", "http://schemas.xmlsoap.org/ws/2005/04/discovery")
-		//typesTag.CreateAttr("xmlns:dp0", "http://www.onvif.org/ver10/network/wsdl")
-		var typesString string
-		for _, j := range types {
-			typesString += j
-			typesString += " "
-		}
-
-		typesTag.SetText(strings.TrimSpace(typesString))
-
+		typesTag.SetText(strings.Join(types, " "))
 		probe.AddChild(typesTag)
 	}
 
 	if len(scopes) != 0 {
 		scopesTag := etree.NewElement("d:Scopes")
-		var scopesString string
-		for _, j := range scopes {
-			scopesString += j
-			scopesString += " "
-		}
-		scopesTag.SetText(strings.TrimSpace(scopesString))
-
+		scopesTag.SetText(strings.Join(scopes, " "))
 		probe.AddChild(scopesTag)
 	}
 


### PR DESCRIPTION
- make interface optional, as it is not always required
- change listener port 1024 to be a dynamically allocated one
- add better log messages
- re-use data buffer
- only search for NetworkVideoTransmitter devices by default
- cleanup probe message generation

Signed-off-by: Anthony Casagrande <anthony.j.casagrande@intel.com>


Related:
- https://github.com/edgexfoundry/device-onvif-camera/issues/135
- https://github.com/edgexfoundry/device-onvif-camera/issues/134