### PR TITLE
fix: correctly define attribute lists for xml parsing

### DIFF
--- a/device/types.go
+++ b/device/types.go
@@ -38,28 +38,24 @@ type NetworkCapabilities struct {
 }
 
 type SecurityCapabilities struct {
-	TLS1_0               xsd.Boolean    `xml:"TLS1_0,attr"`
-	TLS1_1               xsd.Boolean    `xml:"TLS1_1,attr"`
-	TLS1_2               xsd.Boolean    `xml:"TLS1_2,attr"`
-	OnboardKeyGeneration xsd.Boolean    `xml:"OnboardKeyGeneration,attr"`
-	AccessPolicyConfig   xsd.Boolean    `xml:"AccessPolicyConfig,attr"`
-	DefaultAccessPolicy  xsd.Boolean    `xml:"DefaultAccessPolicy,attr"`
-	Dot1X                xsd.Boolean    `xml:"Dot1X,attr"`
-	RemoteUserHandling   xsd.Boolean    `xml:"RemoteUserHandling,attr"`
-	X_509Token           xsd.Boolean    `xml:"X_509Token,attr"`
-	SAMLToken            xsd.Boolean    `xml:"SAMLToken,attr"`
-	KerberosToken        xsd.Boolean    `xml:"KerberosToken,attr"`
-	UsernameToken        xsd.Boolean    `xml:"UsernameToken,attr"`
-	HttpDigest           xsd.Boolean    `xml:"HttpDigest,attr"`
-	RELToken             xsd.Boolean    `xml:"RELToken,attr"`
-	SupportedEAPMethods  EAPMethodTypes `xml:"SupportedEAPMethods,attr"`
-	MaxUsers             int            `xml:"MaxUsers,attr"`
-	MaxUserNameLength    int            `xml:"MaxUserNameLength,attr"`
-	MaxPasswordLength    int            `xml:"MaxPasswordLength,attr"`
-}
-
-type EAPMethodTypes struct {
-	Types []int
+	TLS1_0               xsd.Boolean       `xml:"TLS1_0,attr"`
+	TLS1_1               xsd.Boolean       `xml:"TLS1_1,attr"`
+	TLS1_2               xsd.Boolean       `xml:"TLS1_2,attr"`
+	OnboardKeyGeneration xsd.Boolean       `xml:"OnboardKeyGeneration,attr"`
+	AccessPolicyConfig   xsd.Boolean       `xml:"AccessPolicyConfig,attr"`
+	DefaultAccessPolicy  xsd.Boolean       `xml:"DefaultAccessPolicy,attr"`
+	Dot1X                xsd.Boolean       `xml:"Dot1X,attr"`
+	RemoteUserHandling   xsd.Boolean       `xml:"RemoteUserHandling,attr"`
+	X_509Token           xsd.Boolean       `xml:"X_509Token,attr"`
+	SAMLToken            xsd.Boolean       `xml:"SAMLToken,attr"`
+	KerberosToken        xsd.Boolean       `xml:"KerberosToken,attr"`
+	UsernameToken        xsd.Boolean       `xml:"UsernameToken,attr"`
+	HttpDigest           xsd.Boolean       `xml:"HttpDigest,attr"`
+	RELToken             xsd.Boolean       `xml:"RELToken,attr"`
+	SupportedEAPMethods  onvif.IntAttrList `xml:"SupportedEAPMethods,attr"`
+	MaxUsers             int               `xml:"MaxUsers,attr"`
+	MaxUserNameLength    int               `xml:"MaxUserNameLength,attr"`
+	MaxPasswordLength    int               `xml:"MaxPasswordLength,attr"`
 }
 
 type SystemCapabilities struct {

--- a/xsd/onvif/onvif.go
+++ b/xsd/onvif/onvif.go
@@ -520,10 +520,10 @@ type IPAddressRequest struct {
 
 type IPType xsd.String
 
-//IPv4 address
+// IPv4 address
 type IPv4Address xsd.Token
 
-//IPv6 address
+// IPv6 address
 type IPv6Address xsd.Token
 
 type AudioEncoderConfiguration struct {
@@ -948,7 +948,7 @@ type Transport struct {
 	Tunnel   *Transport         `xml:"onvif:Tunnel,omitempty"`
 }
 
-//enum
+// enum
 type TransportProtocol xsd.String
 
 type MediaUri struct {
@@ -1039,9 +1039,7 @@ type OSDImgOptions struct {
 	Extension OSDImgOptionsExtension
 }
 
-type StringAttrList struct {
-	AttrList []string
-}
+type StringAttrList []string
 
 type OSDImgOptionsExtension xsd.AnyType
 
@@ -1075,7 +1073,7 @@ type PTZSpaces struct {
 
 type PTZSpacesExtension xsd.AnyType
 
-//TODO: restriction
+// TODO: restriction
 type AuxiliaryData xsd.String
 
 type PTZNodeExtension struct {
@@ -1102,9 +1100,7 @@ type PTZConfigurationOptions struct {
 	Extension          *PTZConfigurationOptions2  `json:",omitempty" xml:",omitempty"`
 }
 
-type IntAttrList struct {
-	IntAttrList []int
-}
+type IntAttrList []int
 
 type DurationRange struct {
 	Min xsd.Duration
@@ -1349,7 +1345,7 @@ type UserExtension xsd.String
 
 type CapabilityCategory xsd.String
 
-//Capabilities of device
+// Capabilities of device
 type Capabilities struct {
 	Analytics AnalyticsCapabilities
 	Device    DeviceCapabilities
@@ -1360,14 +1356,14 @@ type Capabilities struct {
 	Extension CapabilitiesExtension
 }
 
-//AnalyticsCapabilities Check
+// AnalyticsCapabilities Check
 type AnalyticsCapabilities struct {
 	XAddr                  xsd.AnyURI
 	RuleSupport            xsd.Boolean
 	AnalyticsModuleSupport xsd.Boolean
 }
 
-//DeviceCapabilities Check
+// DeviceCapabilities Check
 type DeviceCapabilities struct {
 	XAddr     xsd.AnyURI
 	Network   NetworkCapabilities
@@ -1377,7 +1373,7 @@ type DeviceCapabilities struct {
 	Extension DeviceCapabilitiesExtension
 }
 
-//NetworkCapabilities Check
+// NetworkCapabilities Check
 type NetworkCapabilities struct {
 	IPFilter          xsd.Boolean
 	ZeroConfiguration xsd.Boolean
@@ -1386,16 +1382,16 @@ type NetworkCapabilities struct {
 	Extension         NetworkCapabilitiesExtension
 }
 
-//NetworkCapabilitiesExtension Check
+// NetworkCapabilitiesExtension Check
 type NetworkCapabilitiesExtension struct {
 	Dot11Configuration xsd.Boolean
 	Extension          NetworkCapabilitiesExtension2
 }
 
-//NetworkCapabilitiesExtension2 Extension2
+// NetworkCapabilitiesExtension2 Extension2
 type NetworkCapabilitiesExtension2 xsd.AnyType
 
-//SystemCapabilities check
+// SystemCapabilities check
 type SystemCapabilities struct {
 	DiscoveryResolve  xsd.Boolean
 	DiscoveryBye      xsd.Boolean
@@ -1590,7 +1586,7 @@ type DynamicDNSInformation struct {
 	Extension DynamicDNSInformationExtension
 }
 
-//TODO: enumeration
+// TODO: enumeration
 type DynamicDNSType xsd.String
 
 type DynamicDNSInformationExtension xsd.AnyType
@@ -1627,7 +1623,7 @@ type NetworkInterfaceConnectionSetting struct {
 	Duplex          *Duplex      `xml:"onvif:Duplex,omitempty" json:"Duplex,omitempty"`
 }
 
-//TODO: enum
+// TODO: enum
 type Duplex xsd.String
 
 type NetworkInterfaceExtension struct {
@@ -1669,19 +1665,19 @@ type Dot11PSKPassphrase xsd.String
 
 type Dot11PSK xsd.HexBinary
 
-//TODO: enumeration
+// TODO: enumeration
 type Dot11Cipher xsd.String
 
-//TODO: enumeration
+// TODO: enumeration
 type Dot11SecurityMode xsd.String
 
-//TODO: restrictions
+// TODO: restrictions
 type NetworkInterfaceConfigPriority xsd.Integer
 
-//TODO: enumeration
+// TODO: enumeration
 type Dot11StationMode xsd.String
 
-//TODO: restrictions
+// TODO: restrictions
 type Dot11SSIDType xsd.HexBinary
 
 type Dot3Configuration xsd.String
@@ -1708,7 +1704,7 @@ type PrefixedIPv6Address struct {
 	PrefixLength xsd.Int     `xml:"PrefixLength,omitempty" json:"PrefixLength,omitempty"`
 }
 
-//TODO: enumeration
+// TODO: enumeration
 type IPv6DHCPConfiguration xsd.String
 
 type IPv4NetworkInterface struct {
@@ -1723,7 +1719,7 @@ type IPv4Configuration struct {
 	DHCP      *xsd.Boolean         `json:"DHCP,omitempty"`
 }
 
-//optional, unbounded
+// optional, unbounded
 type PrefixedIPv4Address struct {
 	Address      IPv4Address `xml:"Address" json:"Address,omitempty"`
 	PrefixLength xsd.Int     `xml:"PrefixLength" json:"PrefixLength,omitempty"`
@@ -1775,7 +1771,7 @@ type NetworkProtocolRequest struct {
 
 type NetworkProtocolExtension xsd.AnyType
 
-//TODO: enumeration
+// TODO: enumeration
 type NetworkProtocolType xsd.String
 
 type NetworkGateway struct {
@@ -1806,11 +1802,11 @@ type IPAddressFilter struct {
 
 type IPAddressFilterExtension xsd.AnyType
 
-//enum { 'Allow', 'Deny' }
-//TODO: enumeration
+// enum { 'Allow', 'Deny' }
+// TODO: enumeration
 type IPAddressFilterType xsd.String
 
-//TODO: attribite <xs:attribute ref="xmime:contentType" use="optional"/>
+// TODO: attribite <xs:attribute ref="xmime:contentType" use="optional"/>
 type BinaryData struct {
 	X    ContentType      `xml:"xmime:contentType,attr"`
 	Data xsd.Base64Binary `xml:"Data"`
@@ -1837,13 +1833,13 @@ type RelayOutputSettings struct {
 	IdleState RelayIdleState `xml:"IdleState"`
 }
 
-//TODO:enumeration
+// TODO:enumeration
 type RelayIdleState xsd.String
 
-//TODO: enumeration
+// TODO: enumeration
 type RelayMode xsd.String
 
-//TODO: enumeration
+// TODO: enumeration
 type RelayLogicalState xsd.String
 
 type CertificateWithPrivateKey struct {
@@ -1919,7 +1915,7 @@ type Dot11Status struct {
 	ActiveConfigAlias ReferenceToken
 }
 
-//TODO: enumeration
+// TODO: enumeration
 type Dot11SignalStrength xsd.String
 
 type Dot11AvailableNetworks struct {
@@ -1934,7 +1930,7 @@ type Dot11AvailableNetworks struct {
 
 type Dot11AvailableNetworksExtension xsd.AnyType
 
-//TODO: enumeration
+// TODO: enumeration
 type Dot11AuthAndMangementSuite xsd.String
 
 type SystemLogUriList struct {


### PR DESCRIPTION
closes #22 

![image](https://user-images.githubusercontent.com/48735240/221067521-71b03a56-850f-4132-9712-13d2552dd08b.png)

notice SupportedEAPMethods is correctly returned.
