### PR TITLE
Set device info from scopes on discovery

### DIFF
--- a/Device_test.go
+++ b/Device_test.go
@@ -1,0 +1,24 @@
+package onvif
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDevice_SetDeviceInfoFromScopes(t *testing.T) {
+	const (
+		name     = "DeviceName"
+		hardware = "M9000"
+	)
+	scopes := []string{
+		"onvif://www.onvif.org/Profile/Streaming",
+		"onvif://www.onvif.org/SomethingElse/value",
+		"onvif://www.onvif.org/name/" + name,
+		"onvif://www.onvif.org/hardware/" + hardware,
+	}
+	device := Device{}
+	device.SetDeviceInfoFromScopes(scopes)
+	assert.Equal(t, device.info.Name, name)
+	assert.Equal(t, device.info.Model, hardware)
+}

--- a/ws-discovery/networking.go
+++ b/ws-discovery/networking.go
@@ -94,6 +94,13 @@ func DevicesFromProbeResponses(probeResponses []string) ([]onvif.Device, error) 
 				continue
 			}
 
+			var scopes []string
+			ref := probeMatch.FindElement("./Scopes")
+			if ref != nil {
+				scopes = strings.Split(ref.Text(), " ")
+			}
+			dev.SetDeviceInfoFromScopes(scopes)
+
 			xaddrSet[xaddr] = struct{}{}
 			nvtDevices = append(nvtDevices, *dev)
 			// TODO: Add logger for fmt.Printf("Onvif WS-Discovery: Find Xaddr: %-25s EndpointRefAddress: %s\n", xaddr, string(endpointRefAddress))

--- a/ws-discovery/networking_test.go
+++ b/ws-discovery/networking_test.go
@@ -48,7 +48,7 @@ func TestDevicesFromProbeResponses(t *testing.T) {
 
 	devices, err := DevicesFromProbeResponses(probeResponses)
 	require.NoError(t, err)
-	assert.Equal(t, 2, len(devices))
+	require.Equal(t, 2, len(devices))
 	assert.Equal(t, devices[0].GetDeviceParams().Xaddr, "192.168.12.123")
 	assert.Equal(t, devices[0].GetDeviceParams().EndpointRefAddress, "cea94000-fb96-11b3-8260-686dbc5cb15d")
 	assert.Equal(t, devices[1].GetDeviceParams().Xaddr, "192.168.12.128:2020")


### PR DESCRIPTION
Currently only name and hardware (model) are used since only they have corresponding DeviceInfo fields. The other two standard scopes that are not yet stored are location and profile.

One detail is that in the spec it's described that a single scope can have multiple values. This is not taken into consideration in this implementation.

See section 7.3.2.2 Scopes in the ONVIF core spec: https://www.onvif.org/specs/core/ONVIF-Core-Specification.pdf