### PR TITLE
fix: Correct XML marshaling for imaging and video source configuration

### DIFF
--- a/imaging/types.go
+++ b/imaging/types.go
@@ -21,7 +21,7 @@ type GetImagingSettings struct {
 }
 
 type GetImagingSettingsResponse struct {
-	ImagingSettings onvif.ImagingSettings20 `xml:"timg:ImagingSettings"`
+	ImagingSettings onvif.ImagingSettings20
 }
 
 type SetImagingSettings struct {

--- a/media/types.go
+++ b/media/types.go
@@ -471,9 +471,9 @@ type GetCompatibleAudioDecoderConfigurationsResponse struct {
 }
 
 type SetVideoSourceConfiguration struct {
-	XMLName          string                         `xml:"trt:SetVideoSourceConfiguration"`
-	Configuration    onvif.VideoSourceConfiguration `xml:"trt:Configuration"`
-	ForcePersistence xsd.Boolean                    `xml:"trt:ForcePersistence"`
+	XMLName          string                                `xml:"trt:SetVideoSourceConfiguration"`
+	Configuration    onvif.VideoSourceConfigurationRequest `xml:"trt:Configuration"`
+	ForcePersistence xsd.Boolean                           `xml:"trt:ForcePersistence"`
 }
 
 type SetVideoSourceConfigurationResponse struct {

--- a/xsd/onvif/onvif.go
+++ b/xsd/onvif/onvif.go
@@ -400,6 +400,22 @@ type VideoSourceConfigurationExtension2 struct {
 	SceneOrientation SceneOrientation `xml:"SceneOrientation"`
 }
 
+type VideoSourceConfigurationRequest struct {
+	ConfigurationEntityRequest
+	SourceToken *ReferenceToken                           `xml:"onvif:SourceToken,omitempty"`
+	Bounds      *IntRectangle                             `xml:"onvif:Bounds,omitempty"`
+	Extension   *VideoSourceConfigurationExtensionRequest `xml:"onvif:Extension,omitempty"`
+}
+
+type VideoSourceConfigurationExtensionRequest struct {
+	Rotate *RotateRequest `xml:"onvif:Rotate,omitempty"`
+}
+
+type RotateRequest struct {
+	Mode   RotateMode `xml:"onvif:Mode"`
+	Degree xsd.Int    `xml:"onvif:Degree,omitempty"`
+}
+
 type LensDescription struct {
 	FocalLength float64        `xml:"FocalLength,attr"`
 	Offset      LensOffset     `xml:"Offset"`


### PR DESCRIPTION
[why]
GetImagingSettingsResponse will always respond with an empty struct as it does not unmarshal the response and therefore never works.
SetVideoSourceConfiguration uses VideoSourceConfiguration which also fails everytime SetVideoSourceConfiguration called

[how]
Remove namespace tag from GetImagingSettingsResponse
Add VideoSourceConfigurationRequest for SetVideoSourceConfiguration 