### PR TITLE
feat: allow overriding clock for WS-UsernameToken

### DIFF
--- a/Device.go
+++ b/Device.go
@@ -13,6 +13,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/IOTechSystems/onvif/device"
 	"github.com/IOTechSystems/onvif/gosoap"
@@ -100,6 +101,14 @@ type DeviceParams struct {
 	Password           string
 	HttpClient         *http.Client
 	AuthMode           string
+	Now                func() time.Time
+}
+
+func (dev *Device) now() time.Time {
+	if dev.params.Now != nil {
+		return dev.params.Now()
+	}
+	return time.Now()
 }
 
 // GetServices return available endpoints
@@ -266,7 +275,7 @@ func (dev *Device) SendSoap(endpoint string, xmlRequestBody string) (resp *http.
 	soap.AddStringBodyContent(xmlRequestBody)
 	soap.AddRootNamespaces(Xlmns)
 	if dev.params.AuthMode == UsernameTokenAuth || dev.params.AuthMode == Both {
-		err = soap.AddWSSecurity(dev.params.Username, dev.params.Password)
+		err = soap.AddWSSecurityAt(dev.params.Username, dev.params.Password, dev.now())
 		if err != nil {
 			return nil, fmt.Errorf("send soap request failed: %w", err)
 		}
@@ -377,7 +386,7 @@ func (dev *Device) SendGetSnapshotRequest(url string) (resp *http.Response, err 
 	soap.AddRootNamespaces(Xlmns)
 	switch dev.params.AuthMode {
 	case UsernameTokenAuth:
-		err = soap.AddWSSecurity(dev.params.Username, dev.params.Password)
+		err = soap.AddWSSecurityAt(dev.params.Username, dev.params.Password, dev.now())
 		if err != nil {
 			return nil, fmt.Errorf("send GetSnapshotRequest failed: %w", err)
 		}
@@ -390,7 +399,7 @@ func (dev *Device) SendGetSnapshotRequest(url string) (resp *http.Response, err 
 		req.SetBasicAuth(dev.params.Username, dev.params.Password)
 		resp, err = dev.params.HttpClient.Do(req)
 	case DigestAuth, Both:
-		err = soap.AddWSSecurity(dev.params.Username, dev.params.Password)
+		err = soap.AddWSSecurityAt(dev.params.Username, dev.params.Password, dev.now())
 		if err != nil {
 			return nil, fmt.Errorf("send GetSnapshotRequest failed: %w", err)
 		}

--- a/Device_test.go
+++ b/Device_test.go
@@ -60,9 +60,9 @@ func TestDevice_UsesNowForWSSecurityCreated(t *testing.T) {
 	// Every sender that builds a WS-UsernameToken header must go through dev.now().
 	resp, err := dev.SendSoap(srv.URL, "<tds:GetSystemDateAndTime/>")
 	require.NoError(t, err)
-	resp.Body.Close()
+	require.NoError(t, resp.Body.Close())
 
 	resp, err = dev.SendGetSnapshotRequest(srv.URL)
 	require.NoError(t, err)
-	resp.Body.Close()
+	require.NoError(t, resp.Body.Close())
 }

--- a/Device_test.go
+++ b/Device_test.go
@@ -1,9 +1,14 @@
 package onvif
 
 import (
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDevice_SetDeviceInfoFromScopes(t *testing.T) {
@@ -21,4 +26,43 @@ func TestDevice_SetDeviceInfoFromScopes(t *testing.T) {
 	device.SetDeviceInfoFromScopes(scopes)
 	assert.Equal(t, device.info.Name, name)
 	assert.Equal(t, device.info.Model, hardware)
+}
+
+func TestDevice_now(t *testing.T) {
+	fixed := time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC)
+
+	dev := Device{params: DeviceParams{Now: func() time.Time { return fixed }}}
+	assert.Equal(t, fixed, dev.now())
+
+	dev = Device{}
+	assert.WithinDuration(t, time.Now(), dev.now(), time.Second)
+}
+
+func TestDevice_UsesNowForWSSecurityCreated(t *testing.T) {
+	// Camera clock is skewed: a fixed non-UTC "now" must render as UTC in the WS-Security Created.
+	fixed := time.Date(2020, 1, 2, 3, 4, 5, 600000000, time.FixedZone("CET", 3600))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		b, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		assert.Contains(t, string(b), ">2020-01-02T02:04:05.6Z</Created>")
+	}))
+	defer srv.Close()
+
+	dev := Device{params: DeviceParams{
+		Username:   "user",
+		Password:   "pass",
+		AuthMode:   UsernameTokenAuth,
+		HttpClient: srv.Client(),
+		Now:        func() time.Time { return fixed },
+	}}
+
+	// Every sender that builds a WS-UsernameToken header must go through dev.now().
+	resp, err := dev.SendSoap(srv.URL, "<tds:GetSystemDateAndTime/>")
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	resp, err = dev.SendGetSnapshotRequest(srv.URL)
+	require.NoError(t, err)
+	resp.Body.Close()
 }

--- a/gosoap/soap-builder.go
+++ b/gosoap/soap-builder.go
@@ -3,6 +3,7 @@ package gosoap
 import (
 	"encoding/xml"
 	"log"
+	"time"
 
 	"github.com/beevik/etree"
 )
@@ -246,14 +247,15 @@ func buildSoapRoot() *etree.Document {
 
 // AddWSSecurity Header for soapMessage
 func (msg *SoapMessage) AddWSSecurity(username, password string) error {
-	//doc := etree.NewDocument()
-	//if err := doc.ReadFromString(msg.String()); err != nil {
-	//	log.Println(err.Error())
-	//}
+	return msg.AddWSSecurityAt(username, password, time.Now())
+}
+
+// AddWSSecurityAt is AddWSSecurity with an explicit Created time.
+func (msg *SoapMessage) AddWSSecurityAt(username, password string, now time.Time) error {
 	/*
 		Getting an WS-Security struct representation
 	*/
-	auth := NewSecurity(username, password)
+	auth := NewSecurityAt(username, password, now)
 
 	/*
 		Adding WS-Security namespaces to root element of SOAP message

--- a/gosoap/ws-security.go
+++ b/gosoap/ws-security.go
@@ -61,12 +61,18 @@ type wsAuth struct {
 
 // NewSecurity get a new security
 func NewSecurity(username, passwd string) Security {
+	return NewSecurityAt(username, passwd, time.Now())
+}
+
+// NewSecurityAt builds a security header with Created set to now.
+// Pass a time adjusted to the camera's clock when it is skewed from ours.
+func NewSecurityAt(username, passwd string, now time.Time) Security {
 	/** Generating Nonce sequence **/
 	charsToGenerate := 32
 	charSet := gostrgen.Lower | gostrgen.Digit
 
 	nonceSeq := gostrgen.RandGen(charsToGenerate, charSet, "", "")
-	created := time.Now().UTC().Format(time.RFC3339Nano)
+	created := now.UTC().Format(time.RFC3339Nano)
 	auth := Security{
 		Auth: wsAuth{
 			Username: username,


### PR DESCRIPTION
Resolves https://github.com/IOTechSystems/onvif/issues/113.
Allows overriding the clock for cameras with clock skew.